### PR TITLE
ci: create-pr-new-release.yml - fix workflow input type

### DIFF
--- a/.github/workflows/create-pr-new-release.yml
+++ b/.github/workflows/create-pr-new-release.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       segment:
         description: increment version method
-        type: string
+        type: choice
         required: true
         options:
           - major  # 1.0.0 to 2.0.0

--- a/.github/workflows/create-pr-new-release.yml
+++ b/.github/workflows/create-pr-new-release.yml
@@ -8,10 +8,11 @@ on:
         type: choice
         required: true
         options:
-          - major  # 1.0.0 to 2.0.0
-          - minor  # 1.0.0 to 1.1.0
-          - micro  # 1.0.0 to 1.0.1
-          - dev  # 1.0.0 to 1.0.0dev0
+          - dev  # 1.0.0.dev0 to 1.0.0.dev1 or 1.0.0 to 1.0.0.dev0
+          - patch  # 1.0.0 to 1.0.1
+          - minor,dev  # 1.0.0 to 1.1.0.dev0
+          - major,dev  # 1.0.0 to 2.0.0.dev0
+          - release  # 1.0.0.dev0 to 1.0.0
 
 env:
   branch-name: "version-update"


### PR DESCRIPTION
## Test Evidence

Manually trigger workflow with the following options and check version increment (existing version: `0.1.17.dev0`):

- dev: https://github.com/fairy-select/chronovoyage/pull/26
- patch: https://github.com/fairy-select/chronovoyage/pull/27
- minor,dev: https://github.com/fairy-select/chronovoyage/pull/30
- major,dev: https://github.com/fairy-select/chronovoyage/pull/28
- release: https://github.com/fairy-select/chronovoyage/pull/29